### PR TITLE
fix: Prevent page reload on pagination button clicks and add styles

### DIFF
--- a/src/class/get-flatFile.ts
+++ b/src/class/get-flatFile.ts
@@ -15,7 +15,7 @@ class FileViewer {
 		root.innerHTML = /*html*/`
 			<form>
 				<input class='arch' type="file" accept=".csv">
-				<div id="fileContent"></div> <!-- Elemento para mostrar el contenido -->
+				<div id="fileContent"></div>
 			</form>
 		`;
 
@@ -23,6 +23,7 @@ class FileViewer {
 		const fileContentElement = document.getElementById('fileContent');
 
 		inputElement.addEventListener('change', (event) => {
+			event.preventDefault();
 			this.handleFileChange(event, fileContentElement);
 		});
 	}
@@ -57,27 +58,72 @@ class FileViewer {
 	private displayData(data: any[], fileContentElement: HTMLElement): void {
 		const table = document.createElement('table');
 		const headerRow = table.insertRow();
-	
-		const keys = Object.keys(data[0]);
+
+		const rowsPerPage = 15;
+		let currentPage = 1;
+		let totalPages = Math.ceil(data.length / rowsPerPage);
+
+		let keys = Object.keys(data[0]);
+
 		keys.forEach(key => {
 			const th = document.createElement('th');
 			th.textContent = key;
 			headerRow.appendChild(th);
 		});
-	
-		data.forEach(row => {
-			const dataRow = table.insertRow();
-			keys.forEach(key => {
-				const cell = dataRow.insertCell();
-				cell.textContent = row[key];
-			});
-		});
-	
-		fileContentElement.innerHTML = '';
-		fileContentElement.appendChild(table);
-	}
+	  
+		table.appendChild(headerRow);   
 
-	
+		const createPage = (start: number, end: number) => {
+			table.innerHTML = '';
+
+			table.appendChild(headerRow.cloneNode(true));
+
+			for (let i = start; i < end; i++) {
+				const dataRow = table.insertRow();
+				keys.forEach(key => {
+					const cell = dataRow.insertCell();
+					cell.textContent = data[i][key];
+				});
+			}
+		};
+
+		const start = (currentPage - 1) * rowsPerPage;
+		const end = start + rowsPerPage;
+		createPage(start, end);
+
+		const prevButton = document.createElement('button');
+		prevButton.textContent = 'Prev';
+		prevButton.addEventListener('click', (event) => {
+			event.preventDefault();
+			if (currentPage > 1) {
+				currentPage--;
+				updatePage();
+			}
+		});
+		
+		const nextButton = document.createElement('button');
+		nextButton.textContent = 'Next';
+		nextButton.addEventListener('click', (event) => {
+			event.preventDefault();
+			if (currentPage < totalPages) {
+				currentPage++;
+				updatePage();
+			}
+		});
+
+		const paginationControls = document.createElement('div');
+		paginationControls.appendChild(prevButton);
+		paginationControls.appendChild(nextButton);
+
+		fileContentElement.appendChild(table);
+		fileContentElement.appendChild(paginationControls);
+
+		const updatePage = () => {
+			const start = (currentPage - 1) * rowsPerPage;
+			const end = start + rowsPerPage;
+			createPage(start, end);
+		};
+	}
 }
 
 export default FileViewer;

--- a/src/style.css
+++ b/src/style.css
@@ -31,3 +31,23 @@ input[type="file"] {
     border-radius: 4px;
     font-size: 16px;
 }
+
+button {
+    padding: 10px 20px;
+    margin: 10px;
+    border: none;
+    background-color: rgb(148, 148, 148);
+    color: white;
+    font-size: 16px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+button:disabled {
+    background-color: #cccccc;
+    cursor: not-allowed;
+}


### PR DESCRIPTION

- Added event.preventDefault() to the click event listeners for the "Prev" and "Next" buttons.
- Ensured that the page does not reload when navigating between pages.
- Updated the pagination controls to properly handle page updates without losing information.
- Added styles to the "Prev" and "Next" buttons for better user experience.